### PR TITLE
feat: implement OTel-shaped logging and error taxonomy

### DIFF
--- a/docs/standards/error-management.md
+++ b/docs/standards/error-management.md
@@ -1,26 +1,66 @@
 # Error Management Standard
 
 ## Taxonomy
-- `VALIDATION_ERROR`
-- `CONTEXT_ERROR`
-- `POLICY_DENY`
-- `NETWORK_ERROR`
-- `UPSTREAM_ERROR`
-- `INTERNAL_ERROR`
 
-## Wrapping
+All errors are typed. Use one of:
+
+| Type | Meaning |
+|------|---------|
+| `VALIDATION_ERROR` | Schema validation failed, invalid input |
+| `CONTEXT_ERROR` | Missing or invalid context (e.g., no active schema) |
+| `POLICY_DENY` | Action denied by policy |
+| `NETWORK_ERROR` | Network request failed (connection, timeout) |
+| `UPSTREAM_ERROR` | External API returned error (4xx, 5xx) |
+| `INTERNAL_ERROR` | Unexpected internal error |
+
+## Error Response Format
+
 All command handlers return envelope errors:
-`{ ok:false, command, data:null, error:{code,message,details}, meta }`
 
-## Propagation
-- Throw typed errors internally.
-- Convert to envelope in CLI boundary.
-- Never leak secrets in messages.
+```json
+{
+  "ok": false,
+  "command": "use",
+  "data": null,
+  "error": {
+    "type": "VALIDATION_ERROR",
+    "code": "VALIDATION_ERROR",
+    "message": "Failed to fetch schema: 404",
+    "details": { "url": "..." }
+  },
+  "meta": {
+    "schemaVersion": "cli.v1",
+    "timestamp": "2026-02-21T02:10:35.326Z"
+  }
+}
+```
 
-## Retries
-- Retry only idempotent GETs by policy.
-- No implicit retry for unsafe write operations.
+## Propagation Rules
 
-## User-facing errors
-- concise, actionable, deterministic
-- include next step hints when possible
+1. Throw typed errors internally
+2. Convert to envelope at CLI boundary
+3. Never leak secrets in error messages or details
+4. Include actionable next steps when possible
+
+## Error Type Detection
+
+Errors are automatically classified by pattern matching on error message:
+
+- `VALIDATION_ERROR` — message contains "validation", "invalid schema", "openapi"
+- `CONTEXT_ERROR` — message contains "not found", "missing"
+- `POLICY_DENY` — message contains "denied", "forbidden", "policy"
+- `NETWORK_ERROR` — message contains "fetch", "network", "connect", "econn"
+- `UPSTREAM_ERROR` — message contains "4xx", "5xx", "upstream", "external"
+- `INTERNAL_ERROR` — everything else
+
+## Retry Policy
+
+- Retry only idempotent GET requests
+- No implicit retry for unsafe operations (POST, PUT, DELETE)
+- Respect retry-after headers
+
+## User-Facing Errors
+
+- Concise, actionable, deterministic
+- Include next-step hints when possible
+- Use the proper error type so consumers can programmatically handle

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -1,30 +1,67 @@
 # Logging Standard
 
+## Format
+
+Structured JSON lines to stdout. Each log entry is a JSON object.
+
+## Log Entry Schema
+
+```json
+{
+  "ts": "2026-02-21T02:10:35.326Z",
+  "level": "info",
+  "event": "schema.loaded",
+  "traceId": "19b74852-a869-4b14-8f29-e0891cf98722",
+  "spanId": "optional-span-id",
+  "details": { "key": "value" },
+  "error": {
+    "type": "NETWORK_ERROR",
+    "message": "connection refused",
+    "stack": "Error: ..."
+  },
+  "url": "https://api.example.com/spec",
+  "http": {
+    "request": { "method": "GET" },
+    "response": { "status_code": 200 }
+  }
+}
+```
+
 ## Levels
-- `debug` (local diagnostics)
-- `info` (normal lifecycle)
-- `warn` (degraded behavior)
-- `error` (failed operation)
 
-## Structured schema
-Minimum fields:
-- `ts`
-- `level`
-- `event`
-- `command`
-- `correlationId`
-- `details`
+- `debug` — local diagnostics, verbose
+- `info` — normal lifecycle events
+- `warn` — degraded behavior, recoverable issues
+- `error` — failed operations
 
-## Redaction rules
-Always redact:
-- Authorization headers
-- API keys/tokens
-- cookies/session material
-- PII fields when known
+## Required Fields
 
-## Correlation IDs
-Every command execution should attach a `correlationId` propagated through invoke path.
+- `ts` — ISO 8601 timestamp
+- `level` — log level
+- `event` — what happened (e.g., `schema.loaded`, `fetch.failed`)
+- `traceId` — request/operation correlation ID
+
+## Optional Fields
+
+- `spanId` — for distributed tracing
+- `details` — contextual data
+- `error` — error object with type and message
+- `url`, `http.*` — OTel semantic conventions
+
+## Redaction
+
+Always redact sensitive fields:
+- `authorization`, `authorization_header`
+- `x-api-key`, `api_key`, `apikey`
+- `token`, `access_token`, `refresh_token`
+- `secret`, `password`, `cookie`
+- Any field containing `token`, `secret`, `password`, `key`, or `auth` in the name
+
+## Correlation
+
+Use `traceId` (OTel-compatible term, formerly `correlationId`) to track a single request/operation across components.
 
 ## Sinks
-- stdout (default)
-- file/json sink (optional, future)
+
+- stdout (JSON lines) — primary
+- file sink — future

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ program
       const ctx = await useSchema(target, opts.service);
       printOut(envelope("use", { service: ctx.service, fingerprint: ctx.fingerprint, tools: ctx.tools.length }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("use", "USE_FAILED", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("use", "VALIDATION_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });
@@ -67,7 +67,7 @@ program
       const data = ctx.tools.map((t) => ({ name: t.name, method: t.method.toUpperCase(), path: t.path, description: t.description }));
       printOut(envelope("list", data, { service: ctx.service, schemaFingerprint: ctx.fingerprint }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("list", "NO_ACTIVE_CONTEXT", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("list", "CONTEXT_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });
@@ -92,7 +92,7 @@ program
       };
       printOut(envelope("show", data, { service: ctx.service, schemaFingerprint: ctx.fingerprint }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("show", "SHOW_FAILED", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("show", "CONTEXT_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });
@@ -113,7 +113,7 @@ program
       const result = await invokeTool(tool, { parameters, requestBody });
       printOut(envelope("run", result, { endpoint: tool.name, service: ctx.service, schemaFingerprint: ctx.fingerprint }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("run", "RUN_FAILED", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("run", "CONTEXT_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });
@@ -137,7 +137,7 @@ program
       const data = ctx.tools.filter((t) => [t.name, t.description, t.path].join(" ").toLowerCase().includes(q));
       printOut(envelope("search", data, { service: ctx.service, schemaFingerprint: ctx.fingerprint }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("search", "SEARCH_FAILED", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("search", "INTERNAL_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });
@@ -304,7 +304,7 @@ program
       const result = await invokeTool(tool, { parameters, requestBody });
       printOut(envelope("run", result, { endpoint: tool.name, service: ctx.service, schemaFingerprint: ctx.fingerprint }), opts.format as OutputFormat);
     } catch (e: any) {
-      printOut(envelopeErr("run", "RUN_FAILED", e.message), opts.format as OutputFormat);
+      printOut(envelopeErr("run", "CONTEXT_ERROR", e.message), opts.format as OutputFormat);
       process.exitCode = 1;
     }
   });

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -1,10 +1,21 @@
 export type OutputFormat = "json" | "md" | "table";
 
+export type ErrorType = "VALIDATION_ERROR" | "CONTEXT_ERROR" | "POLICY_DENY" | "NETWORK_ERROR" | "UPSTREAM_ERROR" | "INTERNAL_ERROR";
+
+export const ERROR_TYPE_MESSAGES: Record<ErrorType, string> = {
+  VALIDATION_ERROR: "schema validation failed",
+  CONTEXT_ERROR: "missing or invalid context",
+  POLICY_DENY: "action denied by policy",
+  NETWORK_ERROR: "network request failed",
+  UPSTREAM_ERROR: "external API returned error",
+  INTERNAL_ERROR: "unexpected internal error",
+};
+
 export interface OutputEnvelope<T = unknown> {
   ok: boolean;
   command: string;
   data: T | null;
-  error: { code: string; message: string; details?: unknown } | null;
+  error: { type: ErrorType; code: string; message: string; details?: unknown } | null;
   meta: {
     schemaVersion: "cli.v1";
     timestamp: string;
@@ -22,12 +33,17 @@ export function envelope<T>(command: string, data: T, context?: Record<string, u
   };
 }
 
-export function envelopeErr(command: string, code: string, message: string, details?: unknown): OutputEnvelope<null> {
+export function envelopeErr(
+  command: string,
+  errorType: ErrorType,
+  message: string,
+  details?: unknown
+): OutputEnvelope<null> {
   return {
     ok: false,
     command,
     data: null,
-    error: { code, message, details },
+    error: { type: errorType, code: errorType, message, details },
     meta: { schemaVersion: "cli.v1", timestamp: new Date().toISOString() },
   };
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,175 @@
+import crypto from "node:crypto";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  event: string;
+  traceId: string;
+  spanId?: string;
+  details?: Record<string, unknown>;
+  error?: {
+    type: string;
+    message: string;
+    stack?: string;
+  };
+  // OTel semantic convention fields
+  url?: string;
+  http?: {
+    request?: { method?: string };
+    response?: { status_code?: number };
+  };
+}
+
+export const ERROR_TAXONOMY = {
+  VALIDATION_ERROR: "schema validation failed",
+  CONTEXT_ERROR: "missing or invalid context",
+  POLICY_DENY: "action denied by policy",
+  NETWORK_ERROR: "network request failed",
+  UPSTREAM_ERROR: "external API returned error",
+  INTERNAL_ERROR: "unexpected internal error",
+} as const;
+
+export type ErrorType = keyof typeof ERROR_TAXONOMY;
+
+const REDACTED = "[REDACTED]";
+const SECRET_FIELDS = new Set([
+  "authorization",
+  "authorization_header",
+  "x-api-key",
+  "x-api-key",
+  "apikey",
+  "api_key",
+  "token",
+  "access_token",
+  "refresh_token",
+  "secret",
+  "password",
+  "cookie",
+  "set-cookie",
+  "x-auth-token",
+  "bearer_token",
+]);
+
+function isSecretKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return (
+    SECRET_FIELDS.has(lower) ||
+    lower.includes("token") ||
+    lower.includes("secret") ||
+    lower.includes("password") ||
+    lower.includes("key") ||
+    lower.includes("auth")
+  );
+}
+
+export function redact<T>(obj: T): T {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj === "string") return obj;
+  if (typeof obj === "number" || typeof obj === "boolean") return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => redact(item)) as T;
+  }
+
+  if (typeof obj === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (isSecretKey(key)) {
+        redacted[key] = REDACTED;
+      } else {
+        redacted[key] = redact(value);
+      }
+    }
+    return redacted as T;
+  }
+
+  return obj;
+}
+
+function detectErrorType(err: Error): ErrorType {
+  const msg = err.message.toLowerCase();
+  const name = err.name.toLowerCase();
+
+  if (msg.includes("validation") || msg.includes("invalid schema") || msg.includes("openapi")) {
+    return "VALIDATION_ERROR";
+  }
+  if (msg.includes("no active context") || msg.includes("not found") || msg.includes("missing")) {
+    return "CONTEXT_ERROR";
+  }
+  if (msg.includes("denied") || msg.includes("forbidden") || msg.includes("policy")) {
+    return "POLICY_DENY";
+  }
+  if (msg.includes("fetch") || msg.includes("network") || msg.includes("connect") || msg.includes("econn")) {
+    return "NETWORK_ERROR";
+  }
+  if (msg.includes("4xx") || msg.includes("5xx") || msg.includes("upstream") || msg.includes("external")) {
+    return "UPSTREAM_ERROR";
+  }
+  return "INTERNAL_ERROR";
+}
+
+export function createTraceId(): string {
+  return crypto.randomUUID();
+}
+
+export class Logger {
+  private traceId: string;
+  private baseDetails: Record<string, unknown>;
+
+  constructor(traceId?: string, baseDetails: Record<string, unknown> = {}) {
+    this.traceId = traceId || createTraceId();
+    this.baseDetails = baseDetails;
+  }
+
+  private log(level: LogLevel, event: string, data?: { details?: Record<string, unknown>; error?: Error }): void {
+    const entry: LogEntry = {
+      ts: new Date().toISOString(),
+      level,
+      event,
+      traceId: this.traceId,
+      details: data?.details ? redact({ ...this.baseDetails, ...data.details }) : redact(this.baseDetails),
+    };
+
+    if (data?.error) {
+      entry.error = {
+        type: detectErrorType(data.error),
+        message: data.error.message,
+        stack: data.error.stack,
+      };
+    }
+
+    console.log(JSON.stringify(entry));
+  }
+
+  debug(event: string, details?: Record<string, unknown>): void {
+    this.log("debug", event, { details });
+  }
+
+  info(event: string, details?: Record<string, unknown>): void {
+    this.log("info", event, { details });
+  }
+
+  warn(event: string, details?: Record<string, unknown>): void {
+    this.log("warn", event, { details });
+  }
+
+  error(event: string, err: Error, details?: Record<string, unknown>): void {
+    this.log("error", event, { details, error: err });
+  }
+
+  child(overrides: Partial<LogEntry>): Logger {
+    return new Logger(
+      overrides.traceId || this.traceId,
+      { ...this.baseDetails, ...overrides.details }
+    );
+  }
+
+  getTraceId(): string {
+    return this.traceId;
+  }
+}
+
+// Default logger instance
+export const logger = new Logger();


### PR DESCRIPTION
- Add src/lib/logger.ts with structured JSON logging, redaction, traceId
- Update envelopeErr to use error taxonomy (VALIDATION_ERROR, etc.)
- Update CLI handlers to use proper error types
- Rewrite docs/standards/ to reflect actual implementation
- Remove implementation/plan/docs that shouldn't be in repo